### PR TITLE
Syncing VLFM fork with BDAI

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   vlfm_main_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Change Overview

This is simply a find/replace of `ubuntu-latest` -> `ubuntu-22.04`. Because `ubuntu-latest` will become 24.04 soon. We should pin to 22.04 which matches our development environment.

## Testing Done

Runs on Ubuntu 22.04 system.